### PR TITLE
Create and apply `InterestProfile` combining clicks with topics

### DIFF
--- a/src/poprox_concepts/__init__.py
+++ b/src/poprox_concepts/__init__.py
@@ -1,13 +1,23 @@
 from poprox_concepts import api, domain, internals
-from poprox_concepts.domain import Account, Article, Entity, Mention, ClickHistory
+from poprox_concepts.domain import (
+    Account,
+    AccountInterest,
+    Article,
+    Entity,
+    Mention,
+    ClickHistory,
+    InterestProfile,
+)
 
 __all__ = [
     "api",
     "domain",
     "internals",
     "Account",
+    "AccountInterest",
     "Article",
     "Entity",
     "Mention",
     "ClickHistory",
+    "InterestProfile",
 ]

--- a/src/poprox_concepts/api/recommendations.py
+++ b/src/poprox_concepts/api/recommendations.py
@@ -3,13 +3,13 @@ from uuid import UUID
 
 from pydantic import BaseModel, PositiveInt
 
-from poprox_concepts.domain import Article, ClickHistory
+from poprox_concepts.domain import Article, InterestProfile
 
 
 class RecommendationRequest(BaseModel):
     todays_articles: List[Article]
     past_articles: List[Article]
-    click_histories: List[ClickHistory]
+    interest_profile: InterestProfile
     num_recs: PositiveInt
 
 

--- a/src/poprox_concepts/domain/__init__.py
+++ b/src/poprox_concepts/domain/__init__.py
@@ -1,5 +1,14 @@
 from poprox_concepts.domain.account import Account, AccountInterest
 from poprox_concepts.domain.article import Article, Entity, Mention
 from poprox_concepts.domain.click_history import ClickHistory
+from poprox_concepts.domain.profile import InterestProfile
 
-__all__ = ["Account", "Article", "Entity", "Mention", "ClickHistory", "AccountInterest"]
+__all__ = [
+    "Account",
+    "Article",
+    "Entity",
+    "Mention",
+    "ClickHistory",
+    "AccountInterest",
+    "InterestProfile",
+]

--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -1,0 +1,14 @@
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+from poprox_concepts.domain.click_history import ClickHistory
+from poprox_concepts.domain.account import AccountInterest
+
+
+class InterestProfile(BaseModel):
+    click_history: ClickHistory
+    click_topic_counts: Optional[Dict[str, int]] = None
+    onboarding_topics: List[AccountInterest]

--- a/src/poprox_concepts/domain/topics.py
+++ b/src/poprox_concepts/domain/topics.py
@@ -1,0 +1,16 @@
+GENERAL_TOPICS = [
+    "U.S. news",
+    "World news",
+    "Politics",
+    "Business",
+    "Entertainment",
+    "Sports",
+    "Health",
+    "Science",
+    "Technology",
+    "Lifestyle",
+    "Religion",
+    "Climate and environment",
+    "Education",
+    "Oddities",
+]


### PR DESCRIPTION
This changes the format of the recommendation request to incorporate user interest profile information beyond clicks, like on-boarding topic selections.