### PR TITLE
Add a `profile_id` field to `InterestProfile`

### DIFF
--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -1,14 +1,13 @@
-from typing import Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
 
-
-from poprox_concepts.domain.click_history import ClickHistory
 from poprox_concepts.domain.account import AccountInterest
+from poprox_concepts.domain.click_history import ClickHistory
 
 
 class InterestProfile(BaseModel):
+    profile_id: UUID | None = None
     click_history: ClickHistory
-    click_topic_counts: Optional[Dict[str, int]] = None
-    onboarding_topics: List[AccountInterest]
+    click_topic_counts: dict[str, int] | None = None
+    onboarding_topics: list[AccountInterest]


### PR DESCRIPTION
This will be the field we provide to recommenders as a semi-stable identifier for the users/accounts they make recommendations for. It can be filled in with either an account id (for our default recommender) or an assignment/allocation id (for experiment recommenders.)