### PR TITLE
Add optional `raw_data`, `source`, `external_id` fields to `Article`

### DIFF
--- a/src/poprox_concepts/domain/article.py
+++ b/src/poprox_concepts/domain/article.py
@@ -1,22 +1,22 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel
 
 
 class Entity(BaseModel):
-    entity_id: Optional[UUID] = None
-    external_id: Optional[str] = None
+    entity_id: UUID | None = None
+    external_id: str | None = None
     name: str
     entity_type: str
     source: str
-    raw_data: Dict[str, Any]
+    raw_data: dict[str, Any]
 
 
 class Mention(BaseModel):
-    article_id: Optional[UUID] = None
-    mention_id: Optional[UUID] = None
+    article_id: UUID | None = None
+    mention_id: UUID | None = None
     source: str
     relevance: float
     entity: Entity
@@ -25,7 +25,10 @@ class Mention(BaseModel):
 class Article(BaseModel):
     article_id: UUID = None
     title: str
-    content: Optional[str] = None
-    url: Optional[str] = None
+    content: str | None = None
+    url: str | None = None
     published_at: datetime = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
-    mentions: List[Mention] = []
+    mentions: list[Mention] = []
+    source: str | None = None
+    external_id: str | None = None
+    raw_data: dict[str, Any] | None = None

--- a/src/poprox_concepts/domain/article.py
+++ b/src/poprox_concepts/domain/article.py
@@ -11,7 +11,7 @@ class Entity(BaseModel):
     name: str
     entity_type: str
     source: str
-    raw_data: dict[str, Any] | None = Field(exclude=True)
+    raw_data: dict[str, Any] | None = Field(exclude=True, default=None)
 
 
 class Mention(BaseModel):
@@ -31,4 +31,4 @@ class Article(BaseModel):
     mentions: list[Mention] = []
     source: str | None = None
     external_id: str | None = None
-    raw_data: dict[str, Any] | None = Field(exclude=True)
+    raw_data: dict[str, Any] | None = Field(exclude=True, default=None)

--- a/src/poprox_concepts/domain/article.py
+++ b/src/poprox_concepts/domain/article.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Entity(BaseModel):
@@ -11,7 +11,7 @@ class Entity(BaseModel):
     name: str
     entity_type: str
     source: str
-    raw_data: dict[str, Any]
+    raw_data: dict[str, Any] | None = Field(exclude=True)
 
 
 class Mention(BaseModel):
@@ -31,4 +31,4 @@ class Article(BaseModel):
     mentions: list[Mention] = []
     source: str | None = None
     external_id: str | None = None
-    raw_data: dict[str, Any] | None = None
+    raw_data: dict[str, Any] | None = Field(exclude=True)


### PR DESCRIPTION
I'm adding these in preparation for fetching article text and pictures, since the information we need to do that is in the raw data but probably not stuff we want to add to our domain objects.