### PR TITLE
Allow extra fields on `InterestProfile` and (new) `ArticleSet` models

### DIFF
--- a/src/poprox_concepts/__init__.py
+++ b/src/poprox_concepts/__init__.py
@@ -3,10 +3,11 @@ from poprox_concepts.domain import (
     Account,
     AccountInterest,
     Article,
-    Entity,
-    Mention,
+    ArticleSet,
     ClickHistory,
+    Entity,
     InterestProfile,
+    Mention,
 )
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "Account",
     "AccountInterest",
     "Article",
+    "ArticleSet",
     "Entity",
     "Mention",
     "ClickHistory",

--- a/src/poprox_concepts/domain/__init__.py
+++ b/src/poprox_concepts/domain/__init__.py
@@ -1,11 +1,12 @@
 from poprox_concepts.domain.account import Account, AccountInterest
-from poprox_concepts.domain.article import Article, Entity, Mention
+from poprox_concepts.domain.article import Article, ArticleSet, Entity, Mention
 from poprox_concepts.domain.click_history import ClickHistory
 from poprox_concepts.domain.profile import InterestProfile
 
 __all__ = [
     "Account",
     "Article",
+    "ArticleSet",
     "Entity",
     "Mention",
     "ClickHistory",

--- a/src/poprox_concepts/domain/article.py
+++ b/src/poprox_concepts/domain/article.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Entity(BaseModel):
@@ -32,3 +32,9 @@ class Article(BaseModel):
     source: str | None = None
     external_id: str | None = None
     raw_data: dict[str, Any] | None = Field(exclude=True, default=None)
+
+
+class ArticleSet(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    articles: list[Article]

--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -1,12 +1,14 @@
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from poprox_concepts.domain.account import AccountInterest
 from poprox_concepts.domain.click_history import ClickHistory
 
 
 class InterestProfile(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     profile_id: UUID | None = None
     click_history: ClickHistory
     click_topic_counts: dict[str, int] | None = None


### PR DESCRIPTION
Configuring these models to accept additional constructor parameters that aren't directly defined on the class provides a way for recommendation components to enrich the user and item representations with additional data they compute or create (like embeddings.)