### PR TITLE
Add optional metadata to recommender responses

### DIFF
--- a/src/poprox_concepts/api/recommendations.py
+++ b/src/poprox_concepts/api/recommendations.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from uuid import UUID
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, Field, PositiveInt
 
 from poprox_concepts.domain import Article, InterestProfile
 
@@ -14,3 +16,15 @@ class RecommendationRequest(BaseModel):
 
 class RecommendationResponse(BaseModel):
     recommendations: dict[UUID, list[Article]]
+    recommender: RecommenderInfo | None = Field(default=None)
+
+
+class RecommenderInfo(BaseModel):
+    """
+    Identity and versioning metadata for the system that generated the provided
+    recommendations.
+    """
+
+    name: str | None = Field(default=None)
+    version: str | None = Field(default=None)
+    hash: str | None = Field(default=None)

--- a/src/poprox_concepts/api/recommendations.py
+++ b/src/poprox_concepts/api/recommendations.py
@@ -25,6 +25,6 @@ class RecommenderInfo(BaseModel):
     recommendations.
     """
 
-    name: str | None = Field(default=None)
-    version: str | None = Field(default=None)
-    hash: str | None = Field(default=None)
+    name: str | None = None
+    version: str | None = None
+    hash: str | None = None


### PR DESCRIPTION
This adds (optional) metadata to the recommendation response model, so we can return it from the recommender class.