### PR TITLE
Replace `ClickHistory` with a list of `Click` objects

### DIFF
--- a/src/poprox_concepts/__init__.py
+++ b/src/poprox_concepts/__init__.py
@@ -4,7 +4,7 @@ from poprox_concepts.domain import (
     AccountInterest,
     Article,
     ArticleSet,
-    ClickHistory,
+    Click,
     Entity,
     InterestProfile,
     Mention,
@@ -18,8 +18,8 @@ __all__ = [
     "AccountInterest",
     "Article",
     "ArticleSet",
+    "Click",
     "Entity",
     "Mention",
-    "ClickHistory",
     "InterestProfile",
 ]

--- a/src/poprox_concepts/domain/__init__.py
+++ b/src/poprox_concepts/domain/__init__.py
@@ -1,6 +1,6 @@
 from poprox_concepts.domain.account import Account, AccountInterest
 from poprox_concepts.domain.article import Article, ArticleSet, Entity, Mention
-from poprox_concepts.domain.click_history import ClickHistory
+from poprox_concepts.domain.click import Click
 from poprox_concepts.domain.image import Image
 from poprox_concepts.domain.profile import InterestProfile
 
@@ -12,7 +12,6 @@ __all__ = [
     "Image",
     "Mention",
     "Click",
-    "ClickHistory",
     "AccountInterest",
     "InterestProfile",
 ]

--- a/src/poprox_concepts/domain/click.py
+++ b/src/poprox_concepts/domain/click.py
@@ -7,4 +7,4 @@ from pydantic import BaseModel
 class Click(BaseModel):
     article_id: UUID
     newsletter_id: UUID | None = None
-    timestamp: datetime
+    timestamp: datetime | None = None

--- a/src/poprox_concepts/domain/click_history.py
+++ b/src/poprox_concepts/domain/click_history.py
@@ -1,7 +1,0 @@
-from uuid import UUID
-
-from pydantic import BaseModel
-
-
-class ClickHistory(BaseModel):
-    article_ids: list[UUID]

--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -3,13 +3,13 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 
 from poprox_concepts.domain.account import AccountInterest
-from poprox_concepts.domain.click_history import ClickHistory
+from poprox_concepts.domain.click import Click
 
 
 class InterestProfile(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     profile_id: UUID | None = None
-    click_history: ClickHistory
+    click_history: list[Click]
     click_topic_counts: dict[str, int] | None = None
     onboarding_topics: list[AccountInterest]


### PR DESCRIPTION
This will give us more information about each click, including which newsletter it came from and when. That should be useful to us in developing logic that filters out clicks from email link scanners, among other things.

Depended on by:
* https://github.com/CCRI-POPROX/poprox-storage/pull/32
* https://github.com/CCRI-POPROX/poprox-recommender/pull/87