### PR TITLE
Rename article `title` and `content` to `headline` and `subhead`

### DIFF
--- a/src/poprox_concepts/domain/article.py
+++ b/src/poprox_concepts/domain/article.py
@@ -24,8 +24,8 @@ class Mention(BaseModel):
 
 class Article(BaseModel):
     article_id: UUID = Field(default_factory=uuid4)
-    title: str
-    content: str | None = None
+    headline: str
+    subhead: str | None = None
     url: str | None = None
     preview_image_id: UUID | None = None
     published_at: datetime = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
These names probably originated with the early articles we scraped directly from AP's website, which were stored with different field names than are commonly used in journalism. Journalists sometimes call these the `hed` and `subhed`/`dek`, so I've adapted those names a bit to be easier for us to use while staying as true to the source domain as I can.

This differentiates the `subhead` (formerly `content`) from the actual text of the article, which we may soon start fetching from AP with additional API calls.

Connected PRs:
* https://github.com/CCRI-POPROX/poprox-concepts/pull/22
* https://github.com/CCRI-POPROX/poprox-storage/pull/40
* https://github.com/CCRI-POPROX/poprox-platform/pull/142
* https://github.com/CCRI-POPROX/poprox-recommender/pull/91