### PR TITLE
add Newsletter to `__init__.py`. 

### DIFF
--- a/src/poprox_concepts/__init__.py
+++ b/src/poprox_concepts/__init__.py
@@ -8,6 +8,7 @@ from poprox_concepts.domain import (
     Entity,
     InterestProfile,
     Mention,
+    Newsletter,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "Entity",
     "InterestProfile",
     "Mention",
+    "Newsletter",
 ]


### PR DESCRIPTION
This matches the other core concepts (available at top level) and also existing imports in the repositories.

Probably a trivial PR but we either need to fix this here or we need to fix line 13 of `poprox-storage/src/poprox_storage/repositories/newsletters.py`