### PR TITLE
Add click_locality_counts field in InterestProfile

### DIFF
--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -11,5 +11,6 @@ class InterestProfile(BaseModel):
 
     profile_id: UUID | None = None
     click_history: list[Click]
-    click_topic_counts: dict[str, int] | None = None
+    click_topic_counts: dict[str, int] | None = None,
+    click_locality_counts: dict[str, int] | None = None,
     onboarding_topics: list[AccountInterest]

--- a/src/poprox_concepts/domain/profile.py
+++ b/src/poprox_concepts/domain/profile.py
@@ -11,6 +11,6 @@ class InterestProfile(BaseModel):
 
     profile_id: UUID | None = None
     click_history: list[Click]
-    click_topic_counts: dict[str, int] | None = None,
-    click_locality_counts: dict[str, int] | None = None,
+    click_topic_counts: dict[str, int] | None = (None,)
+    click_locality_counts: dict[str, int] | None = (None,)
     onboarding_topics: list[AccountInterest]


### PR DESCRIPTION
This change will be used in https://github.com/CCRI-POPROX/poprox-recommender/pull/103 for computing locality calibration logic for each user.