### PR TITLE
Create an `Impression` domain concept model and incorporate it into `Newsletter`

### DIFF
--- a/src/poprox_concepts/domain/__init__.py
+++ b/src/poprox_concepts/domain/__init__.py
@@ -3,7 +3,7 @@ from poprox_concepts.domain.article import Article, ArticlePlacement, ArticleSet
 from poprox_concepts.domain.click import Click
 from poprox_concepts.domain.demographics import Demographics
 from poprox_concepts.domain.image import Image
-from poprox_concepts.domain.newsletter import Newsletter
+from poprox_concepts.domain.newsletter import Impression, Newsletter
 from poprox_concepts.domain.profile import InterestProfile
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "Click",
     "Entity",
     "Image",
+    "Impression",
     "InterestProfile",
     "Mention",
     "Newsletter",

--- a/src/poprox_concepts/domain/newsletter.py
+++ b/src/poprox_concepts/domain/newsletter.py
@@ -8,8 +8,8 @@ from poprox_concepts.domain.article import Article
 
 class Impression(BaseModel):
     newsletter_id: UUID
-    article_id: UUID
     position: int
+    article: Article
     created_at: datetime | None = None
 
 
@@ -17,7 +17,10 @@ class Newsletter(BaseModel):
     newsletter_id: UUID = Field(default_factory=uuid4)
     account_id: UUID
     treatment_id: UUID | None = None
-    articles: list[Article]
+    impressions: list[Impression]
     subject: str
     body_html: str
     created_at: datetime | None = None
+
+    def articles(self) -> list[Article]:
+        return [impression.article for impression in self.impressions]

--- a/src/poprox_concepts/domain/newsletter.py
+++ b/src/poprox_concepts/domain/newsletter.py
@@ -6,6 +6,13 @@ from pydantic import BaseModel, Field
 from poprox_concepts.domain.article import Article
 
 
+class Impression(BaseModel):
+    newsletter_id: UUID
+    article_id: UUID
+    position: int
+    created_at: datetime | None = None
+
+
 class Newsletter(BaseModel):
     newsletter_id: UUID = Field(default_factory=uuid4)
     account_id: UUID

--- a/src/poprox_concepts/domain/newsletter.py
+++ b/src/poprox_concepts/domain/newsletter.py
@@ -22,5 +22,6 @@ class Newsletter(BaseModel):
     body_html: str
     created_at: datetime | None = None
 
+    @property
     def articles(self) -> list[Article]:
         return [impression.article for impression in self.impressions]


### PR DESCRIPTION
We already have a database table for impressions, but haven't had a reason to use them in the platform until we reached exporting experiment result datasets for analysis. This wraps each `Article` in a `Newsletter` with an `Impression`, which makes both storing and loading impressions simpler.