### PR TITLE
Add the experiment_extra field in impression object

### DIFF
--- a/src/poprox_concepts/domain/newsletter.py
+++ b/src/poprox_concepts/domain/newsletter.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -11,6 +12,7 @@ class Impression(BaseModel):
     position: int
     article: Article
     created_at: datetime | None = None
+    experiment_extra: dict[str, Any] | None = None
 
 
 class Newsletter(BaseModel):

--- a/src/poprox_concepts/domain/newsletter.py
+++ b/src/poprox_concepts/domain/newsletter.py
@@ -12,7 +12,7 @@ class Impression(BaseModel):
     position: int
     article: Article
     created_at: datetime | None = None
-    experiment_extra: dict[str, Any] | None = None
+    extra: dict[str, Any] | None = None
 
 
 class Newsletter(BaseModel):


### PR DESCRIPTION
Based on the [discussion](https://ccri-poprox.slack.com/archives/C06NHF3N8AJ/p1733336054620079) in Slack, added the new `experiment_extra` field to store any experiment-relevant log requirements. 

By reading the [newsletter.py](https://github.com/CCRI-POPROX/poprox-storage/blob/main/src/poprox_storage/repositories/newsletters.py) file in `POPROX-storage`, I feel there's a bunch we need to update there as well to properly store the new field. Is there a place I can make DB schema change first? For example, I see currently we're adding [three fields](https://github.com/CCRI-POPROX/poprox-storage/blob/main/src/poprox_storage/repositories/newsletters.py#L43) into`impression_table`.