### PR TITLE
Use `CandidateSet` and `RecommendationList` in request/response classes

### DIFF
--- a/src/poprox_concepts/api/recommendations.py
+++ b/src/poprox_concepts/api/recommendations.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-from uuid import UUID
-
 from pydantic import BaseModel, Field, PositiveInt
 
-from poprox_concepts.domain import Article, InterestProfile
+from poprox_concepts.domain import CandidateSet, InterestProfile, RecommendationList
 
 
 class RecommendationRequest(BaseModel):
-    todays_articles: list[Article]
-    past_articles: list[Article]
+    todays_articles: CandidateSet
+    past_articles: CandidateSet
     interest_profile: InterestProfile
     num_recs: PositiveInt
 
 
 class RecommendationResponse(BaseModel):
-    recommendations: dict[UUID, list[Article]]
+    recommendations: RecommendationList
     recommender: RecommenderInfo | None = Field(default=None)
 
 

--- a/src/poprox_concepts/api/recommendations.py
+++ b/src/poprox_concepts/api/recommendations.py
@@ -6,8 +6,8 @@ from poprox_concepts.domain import CandidateSet, InterestProfile, Recommendation
 
 
 class RecommendationRequest(BaseModel):
-    todays_articles: CandidateSet
-    past_articles: CandidateSet
+    candidates: CandidateSet
+    interacted: CandidateSet
     interest_profile: InterestProfile
     num_recs: PositiveInt
 


### PR DESCRIPTION
This change would allow us to pass additional properties in recommendation requests and responses, which would enable things like:
* Augmenting candidate sets with pre-computed embeddings on the platform side before sending them in the request
* Augmenting recommendation lists with custom per-item logs/extras on the recommender side before returning them to the platform to be recorded in the database