### PR TITLE
Add methods for internal/external account identification

### DIFF
--- a/src/poprox_concepts/domain/account.py
+++ b/src/poprox_concepts/domain/account.py
@@ -35,3 +35,24 @@ COMPENSATION_CARD_OPTIONS = [
     "Walmart",
     "Tango",
 ]
+
+INTERNAL_ACCOUNT_SOURCES = [
+    "friends_of_poprox",
+    "team",
+    "test",
+    "kluver",
+]
+
+EXTERNAL_ACCOUNT_SOURCES = [
+    "website",
+    "ff",
+    "ml-volunteers",
+]
+
+
+def is_internal_account(account: Account) -> bool:
+    return account.source is not None and account.source in INTERNAL_ACCOUNT_SOURCES
+
+
+def is_external_account(account: Account) -> bool:
+    return account.source is not None and account.source in EXTERNAL_ACCOUNT_SOURCES

--- a/src/poprox_concepts/domain/account.py
+++ b/src/poprox_concepts/domain/account.py
@@ -50,6 +50,7 @@ EXTERNAL_ACCOUNT_SOURCES = [
 ]
 
 
+# NOTE: these are not opposites -- a user may be _neither_ internal nor external if the source code is not recognized.
 def is_internal_account(account: Account) -> bool:
     return account.source is not None and account.source in INTERNAL_ACCOUNT_SOURCES
 


### PR DESCRIPTION
The sources are extracted from `poprox-platform` and the database and are turned into methods here in order to create a single source for the logic