### PR TITLE
Relax the Pydantic version to allow upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 keywords = []
 authors = [{ name = "Karl Higley", email = "khigley@umn.edu" }]
-dependencies = ["pydantic~=2.7.1"]
+dependencies = ["pydantic>=2.7.1,<3"]
 
 [project.urls]
 Documentation = "https://github.com/CCRI-POPROX/poprox-concepts#readme"


### PR DESCRIPTION
This relaxes the Pydantic version upper bound, to allow SemVer-compatible upgrades. Newer Pydantic has a function needed by a PR in progress on Recommender.