### PR TITLE
Add Experience model to domain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
       - id: ruff
         args: [--fix]
         name: auto-fix Python lint errors
-      # Run the formatter.
       - id: ruff-format
+        # Run the formatter.
         name: format Python source
   - repo: local
     hooks:
@@ -41,8 +41,8 @@ repos:
         language: node
         additional_dependencies:
           - "@taplo/cli"
-      # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
       - id: format-shell-scripts
+        # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
         name: format shell scripts
         language: golang
         require_serial: true

--- a/src/poprox_concepts/domain/__init__.py
+++ b/src/poprox_concepts/domain/__init__.py
@@ -2,6 +2,7 @@ from poprox_concepts.domain.account import Account, AccountInterest
 from poprox_concepts.domain.article import Article, ArticlePlacement, Entity, Mention, TopNewsHeadline
 from poprox_concepts.domain.click import Click
 from poprox_concepts.domain.demographics import Demographics
+from poprox_concepts.domain.experience import Experience
 from poprox_concepts.domain.image import Image
 from poprox_concepts.domain.newsletter import Impression, Newsletter
 from poprox_concepts.domain.profile import InterestProfile
@@ -23,4 +24,5 @@ __all__ = [
     "Newsletter",
     "RecommendationList",
     "TopNewsHeadline",
+    "Experience",
 ]

--- a/src/poprox_concepts/domain/experience.py
+++ b/src/poprox_concepts/domain/experience.py
@@ -1,0 +1,15 @@
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Experience(BaseModel):
+    experience_id: UUID | None = None
+    name: str
+    recommender_id: UUID
+    team_id: UUID
+    start_date: date
+    end_date: date
+    created_at: datetime | None = None
+    frequency: str | None = None


### PR DESCRIPTION
### Summary

This PR introduces a new `Experience` Pydantic model to the domain layer

### Details

- Added `experience.py` under `poprox_concepts/domain/` defining the `Experience` model

- Updated `__init__.py` to expose `Experience` for import

