### PR TITLE
rewrite V3, with a new version string, to be V2+embeddings

### DIFF
--- a/src/poprox_concepts/api/recommendations/v3.py
+++ b/src/poprox_concepts/api/recommendations/v3.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from uuid import UUID
 
-from pydantic import BaseModel, Field, JsonValue, PositiveInt
+from pydantic import BaseModel, Field, PositiveInt
 
 from poprox_concepts.api.recommendations.versions import ProtocolVersions, RecommenderInfo
-from poprox_concepts.domain.newsletter import Impression
 from poprox_concepts.domain.profile import InterestProfile
-from poprox_concepts.domain.recommendation import CandidateSet
+from poprox_concepts.domain.recommendation import CandidateSet, RecommendationList
 
 
 class ProtocolModelV3_0(BaseModel):
     """
-    Version 3.0 of the POPROX protocol changed the return model of a recommendation to return a list of "sections"
+    Version 3.0 of the POPROX protocol has embeddings in recommendation requests.
     """
 
     protocol_version: ProtocolVersions = Field(default=ProtocolVersions.VERSION_3_0, frozen=True)
@@ -23,21 +22,9 @@ class RecommendationRequestV3(ProtocolModelV3_0):
     interacted: CandidateSet
     interest_profile: InterestProfile
     num_recs: PositiveInt
-
-
-class RecommendationResponseSection(BaseModel):
-    title: str
-    recommendations: RecommendationList_v3
-
-
-Extra: TypeAlias = dict[str, JsonValue]
-
-
-class RecommendationList_v3(ProtocolModelV3_0):
-    impressions: list[Impression] = Field(default_factory=list)
-    extras: list[Extra] = Field(default_factory=list)
+    embeddings: dict[UUID, list[float]]
 
 
 class RecommendationResponseV3(ProtocolModelV3_0):
-    recommendations: list[RecommendationResponseSection]
+    recommendations: RecommendationList
     recommender: RecommenderInfo | None = Field(default=None)

--- a/src/poprox_concepts/api/recommendations/versions.py
+++ b/src/poprox_concepts/api/recommendations/versions.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class ProtocolVersions(Enum):
     VERSION_1_1 = "1.1-2024-08-08"
     VERSION_2_0 = "2.0-2025-02-12"
-    VERSION_3_0 = "3.0-2025-06-10"
+    VERSION_3_0 = "3.0-2025-07-25"
 
 
 class RecommenderInfo(BaseModel):


### PR DESCRIPTION
First stab at redoing V3. 

- Obviously, no testing has been done.
- I opted to keep embeddings simple, `dict[UUID, list[float]]` -- all our images, articles, entities, etc. have a UUID, and unless I miss my mark, right now they have a unique embedding, so I think this should be enough?
- It's a minor thing, but V3 does have a new string, which should help avoid conflict with the old V3. we could name it different (V3_1 or something) if we wanted to make sure code written against the old V3 fails in an obvious enough way.