### PR TITLE
Add Recommendation API V6 candidate catalog contract

### DIFF
--- a/src/poprox_concepts/api/recommendations/__init__.py
+++ b/src/poprox_concepts/api/recommendations/__init__.py
@@ -3,6 +3,7 @@ from poprox_concepts.api.recommendations.v2 import RecommendationRequestV2, Reco
 from poprox_concepts.api.recommendations.v3 import RecommendationRequestV3, RecommendationResponseV3
 from poprox_concepts.api.recommendations.v4 import RecommendationRequestV4, RecommendationResponseV4
 from poprox_concepts.api.recommendations.v5 import RecommendationRequestV5, RecommendationResponseV5
+from poprox_concepts.api.recommendations.v6 import RecommendationRequestV6, RecommendationResponseV6
 
 RecommendationRequest = RecommendationRequestV1
 RecommendationResponse = RecommendationResponseV1
@@ -14,10 +15,12 @@ __all__ = [
     "RecommendationRequestV3",
     "RecommendationRequestV4",
     "RecommendationRequestV5",
+    "RecommendationRequestV6",
     "RecommendationResponse",
     "RecommendationResponseV1",
     "RecommendationResponseV2",
     "RecommendationResponseV3",
     "RecommendationResponseV4",
     "RecommendationResponseV5",
+    "RecommendationResponseV6",
 ]

--- a/src/poprox_concepts/api/recommendations/v6.py
+++ b/src/poprox_concepts/api/recommendations/v6.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import Counter
-from collections.abc import Iterable
 from datetime import datetime
 from uuid import UUID, uuid4
 
@@ -10,11 +8,6 @@ from pydantic import BaseModel, Field, PositiveInt, field_validator, model_valid
 from poprox_concepts.api.recommendations.versions import ProtocolVersions
 from poprox_concepts.domain import Article, ArticlePackage, CandidateSet, InterestProfile
 from poprox_concepts.domain.newsletter import ImpressedSection, Impression, RecommenderInfo
-
-
-def _duplicate_ids(values: Iterable[UUID]) -> list[UUID]:
-    counts = Counter(values)
-    return sorted((value for value, count in counts.items() if count > 1), key=str)
 
 
 class ProtocolModelV6_0(BaseModel):
@@ -27,7 +20,7 @@ class ProtocolModelV6_0(BaseModel):
 
     @field_validator("protocol_version")
     @classmethod
-    def require_v6_protocol(cls, version: ProtocolVersions) -> ProtocolVersions:
+    def _require_v6_protocol(cls, version: ProtocolVersions) -> ProtocolVersions:
         if version != ProtocolVersions.VERSION_6_0:
             raise ValueError(f"protocol_version must be {ProtocolVersions.VERSION_6_0.value}")
         return version
@@ -47,33 +40,35 @@ class RecommendationRequestV6(ProtocolModelV6_0):
     impressed_article_ids: list[UUID] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_article_references(self) -> RecommendationRequestV6:
+    def _validate_article_references(self) -> RecommendationRequestV6:
+        # Catalog article IDs must be unique.
         article_ids = [article.article_id for article in self.articles]
-        duplicate_article_ids = _duplicate_ids(article_ids)
-        if duplicate_article_ids:
-            duplicates = ", ".join(str(article_id) for article_id in duplicate_article_ids)
-            raise ValueError(f"articles contains duplicate article IDs: {duplicates}")
+        duplicate_count = len(article_ids) - len(set(article_ids))
+        if duplicate_count:
+            raise ValueError(f"articles duplicate article ID count: {duplicate_count}")
 
+        # Package IDs must be unique, and the default package must be present.
         package_ids = [package.package_id for package in self.article_packages]
-        duplicate_package_ids = _duplicate_ids(package_ids)
-        if duplicate_package_ids:
-            duplicates = ", ".join(str(package_id) for package_id in duplicate_package_ids)
-            raise ValueError(f"article_packages contains duplicate package IDs: {duplicates}")
+        duplicate_count = len(package_ids) - len(set(package_ids))
+        if duplicate_count:
+            raise ValueError(f"article_packages duplicate package ID count: {duplicate_count}")
 
         if self.default_package_id not in package_ids:
             raise ValueError(f"default_package_id {self.default_package_id} does not match an article package")
 
+        # Package references must be unique within each package and resolve to the catalog.
         catalog_ids = set(article_ids)
         for package in self.article_packages:
-            duplicate_references = _duplicate_ids(package.article_ids)
-            if duplicate_references:
-                duplicates = ", ".join(str(article_id) for article_id in duplicate_references)
-                raise ValueError(f"article package {package.package_id} contains duplicate article IDs: {duplicates}")
+            duplicate_count = len(package.article_ids) - len(set(package.article_ids))
+            if duplicate_count:
+                raise ValueError(f"article package {package.package_id} duplicate article ID count: {duplicate_count}")
 
             unknown_references = sorted(set(package.article_ids) - catalog_ids, key=str)
             if unknown_references:
-                unknown = ", ".join(str(article_id) for article_id in unknown_references)
-                raise ValueError(f"article package {package.package_id} references unknown article IDs: {unknown}")
+                raise ValueError(
+                    f"article package {package.package_id} unknown article reference count: {len(unknown_references)}; "
+                    f"first unknown ID: {unknown_references[0]}"
+                )
 
         return self
 

--- a/src/poprox_concepts/api/recommendations/v6.py
+++ b/src/poprox_concepts/api/recommendations/v6.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, PositiveInt, field_validator, model_validator
+
+from poprox_concepts.api.recommendations.versions import ProtocolVersions
+from poprox_concepts.domain import Article, ArticlePackage, CandidateSet, InterestProfile
+from poprox_concepts.domain.newsletter import ImpressedSection, Impression, RecommenderInfo
+
+
+def _duplicate_ids(values: Iterable[UUID]) -> list[UUID]:
+    counts = Counter(values)
+    return sorted((value for value, count in counts.items() if count > 1), key=str)
+
+
+class ProtocolModelV6_0(BaseModel):
+    """Version 6.0 separates article metadata from default recommendation eligibility."""
+
+    protocol_version: ProtocolVersions = Field(
+        default=ProtocolVersions.VERSION_6_0,
+        frozen=True,
+    )
+
+    @field_validator("protocol_version")
+    @classmethod
+    def require_v6_protocol(cls, version: ProtocolVersions) -> ProtocolVersions:
+        if version != ProtocolVersions.VERSION_6_0:
+            raise ValueError(f"protocol_version must be {ProtocolVersions.VERSION_6_0.value}")
+        return version
+
+
+class RecommendationRequestV6(ProtocolModelV6_0):
+    request_id: UUID = Field(default_factory=uuid4)
+    requested_at: datetime = Field(default_factory=lambda: datetime.now())
+
+    articles: list[Article]
+    interacted: CandidateSet
+    interest_profile: InterestProfile
+    num_recs: PositiveInt
+    embeddings: dict[UUID, dict[str, list[float]]] | None = Field(default=None)
+    article_packages: list[ArticlePackage]
+    default_package_id: UUID
+    impressed_article_ids: list[UUID] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_article_references(self) -> RecommendationRequestV6:
+        article_ids = [article.article_id for article in self.articles]
+        duplicate_article_ids = _duplicate_ids(article_ids)
+        if duplicate_article_ids:
+            duplicates = ", ".join(str(article_id) for article_id in duplicate_article_ids)
+            raise ValueError(f"articles contains duplicate article IDs: {duplicates}")
+
+        package_ids = [package.package_id for package in self.article_packages]
+        duplicate_package_ids = _duplicate_ids(package_ids)
+        if duplicate_package_ids:
+            duplicates = ", ".join(str(package_id) for package_id in duplicate_package_ids)
+            raise ValueError(f"article_packages contains duplicate package IDs: {duplicates}")
+
+        if self.default_package_id not in package_ids:
+            raise ValueError(f"default_package_id {self.default_package_id} does not match an article package")
+
+        catalog_ids = set(article_ids)
+        for package in self.article_packages:
+            duplicate_references = _duplicate_ids(package.article_ids)
+            if duplicate_references:
+                duplicates = ", ".join(str(article_id) for article_id in duplicate_references)
+                raise ValueError(f"article package {package.package_id} contains duplicate article IDs: {duplicates}")
+
+            unknown_references = sorted(set(package.article_ids) - catalog_ids, key=str)
+            if unknown_references:
+                unknown = ", ".join(str(article_id) for article_id in unknown_references)
+                raise ValueError(f"article package {package.package_id} references unknown article IDs: {unknown}")
+
+        return self
+
+
+class RecommendationResponseV6(ProtocolModelV6_0):
+    request_id: UUID | None = None
+
+    recommendations: list[ImpressedSection]
+    recommender: RecommenderInfo | None = Field(default=None)
+
+    @property
+    def impressions(self) -> list[Impression]:
+        impressions = []
+        for section in self.recommendations:
+            impressions.extend(section.impressions)
+        return impressions

--- a/src/poprox_concepts/api/recommendations/versions.py
+++ b/src/poprox_concepts/api/recommendations/versions.py
@@ -7,3 +7,4 @@ class ProtocolVersions(Enum):
     VERSION_3_0 = "3.0-2025-07-25"
     VERSION_4_0 = "4.0-2025-10-20"
     VERSION_5_0 = "5.0-2025-11-14"
+    VERSION_6_0 = "6.0-2026-07-23"

--- a/tests/api/test_v6.py
+++ b/tests/api/test_v6.py
@@ -1,0 +1,154 @@
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from poprox_concepts.api.recommendations import (
+    RecommendationRequest,
+    RecommendationRequestV1,
+    RecommendationRequestV6,
+    RecommendationResponse,
+    RecommendationResponseV1,
+    RecommendationResponseV6,
+)
+from poprox_concepts.api.recommendations.v5 import RecommendationRequestV5
+from poprox_concepts.api.recommendations.versions import ProtocolVersions
+from poprox_concepts.domain import Article, ArticlePackage, CandidateSet, InterestProfile
+from poprox_concepts.domain.newsletter import ImpressedSection, Impression
+
+ARTICLE_1_ID = UUID(int=1)
+ARTICLE_2_ID = UUID(int=2)
+ARTICLE_3_ID = UUID(int=3)
+UNKNOWN_ARTICLE_ID = UUID(int=99)
+DEFAULT_PACKAGE_ID = UUID(int=101)
+SECONDARY_PACKAGE_ID = UUID(int=102)
+MISSING_PACKAGE_ID = UUID(int=199)
+
+
+def article(article_id: UUID) -> Article:
+    return Article(article_id=article_id, headline=f"Article {article_id.int}")
+
+
+def package(package_id: UUID, article_ids: list[UUID]) -> ArticlePackage:
+    return ArticlePackage(
+        package_id=package_id,
+        title=f"Package {package_id.int}",
+        source="test",
+        article_ids=article_ids,
+    )
+
+
+def request(
+    articles: list[Article],
+    article_packages: list[ArticlePackage],
+    default_package_id: UUID,
+) -> RecommendationRequestV6:
+    return RecommendationRequestV6(
+        articles=articles,
+        interacted=CandidateSet(articles=[]),
+        interest_profile=InterestProfile(entity_interests=[], click_history=[]),
+        num_recs=15,
+        embeddings={},
+        article_packages=article_packages,
+        default_package_id=default_package_id,
+    )
+
+
+def test_v6_request_round_trip_separates_catalog_from_default_package() -> None:
+    articles = [article(ARTICLE_1_ID), article(ARTICLE_2_ID), article(ARTICLE_3_ID)]
+    default_package = package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID, ARTICLE_2_ID])
+    secondary_package = package(SECONDARY_PACKAGE_ID, [ARTICLE_2_ID, ARTICLE_3_ID])
+
+    original = request(articles, [default_package, secondary_package], DEFAULT_PACKAGE_ID)
+    restored = RecommendationRequestV6.model_validate_json(original.model_dump_json())
+
+    assert restored == original
+    assert ARTICLE_2_ID in default_package.article_ids and ARTICLE_2_ID in secondary_package.article_ids
+    assert ARTICLE_3_ID not in default_package.article_ids
+
+    empty = request(
+        [],
+        [package(DEFAULT_PACKAGE_ID, []), package(SECONDARY_PACKAGE_ID, [])],
+        DEFAULT_PACKAGE_ID,
+    )
+    assert RecommendationRequestV6.model_validate_json(empty.model_dump_json()) == empty
+
+
+@pytest.mark.parametrize(
+    ("articles", "article_packages", "default_package_id", "message"),
+    [
+        (
+            [article(ARTICLE_1_ID), article(ARTICLE_1_ID)],
+            [package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID])],
+            DEFAULT_PACKAGE_ID,
+            f"articles contains duplicate article IDs: {ARTICLE_1_ID}",
+        ),
+        (
+            [article(ARTICLE_1_ID)],
+            [
+                package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID]),
+                package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID]),
+            ],
+            DEFAULT_PACKAGE_ID,
+            f"article_packages contains duplicate package IDs: {DEFAULT_PACKAGE_ID}",
+        ),
+        (
+            [article(ARTICLE_1_ID)],
+            [package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID, ARTICLE_1_ID])],
+            DEFAULT_PACKAGE_ID,
+            f"article package {DEFAULT_PACKAGE_ID} contains duplicate article IDs: {ARTICLE_1_ID}",
+        ),
+        (
+            [article(ARTICLE_1_ID)],
+            [package(DEFAULT_PACKAGE_ID, [UNKNOWN_ARTICLE_ID])],
+            DEFAULT_PACKAGE_ID,
+            f"article package {DEFAULT_PACKAGE_ID} references unknown article IDs: {UNKNOWN_ARTICLE_ID}",
+        ),
+        (
+            [article(ARTICLE_1_ID)],
+            [package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID])],
+            MISSING_PACKAGE_ID,
+            f"default_package_id {MISSING_PACKAGE_ID} does not match an article package",
+        ),
+    ],
+)
+def test_v6_request_rejects_invalid_catalog_and_package_relationships(
+    articles: list[Article],
+    article_packages: list[ArticlePackage],
+    default_package_id: UUID,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        request(articles, article_packages, default_package_id)
+
+
+def test_v6_request_rejects_another_known_protocol_version() -> None:
+    valid = request([], [package(DEFAULT_PACKAGE_ID, [])], DEFAULT_PACKAGE_ID)
+    payload = valid.model_dump(mode="json")
+    payload["protocol_version"] = ProtocolVersions.VERSION_5_0.value
+
+    with pytest.raises(ValidationError, match="protocol_version must be 6.0-2026-07-23"):
+        RecommendationRequestV6.model_validate(payload)
+
+
+def test_v6_response_round_trip_preserves_flattened_impressions() -> None:
+    impression = Impression(article=article(ARTICLE_1_ID))
+    original = RecommendationResponseV6(recommendations=[ImpressedSection(title="Top News", impressions=[impression])])
+    restored = RecommendationResponseV6.model_validate_json(original.model_dump_json())
+
+    assert restored == original
+    assert restored.impressions == [impression]
+
+
+def test_v6_exports_do_not_change_existing_aliases_or_v5_shape() -> None:
+    assert (RecommendationRequest, RecommendationResponse) == (RecommendationRequestV1, RecommendationResponseV1)
+    v5 = RecommendationRequestV5(
+        candidates=CandidateSet(articles=[]),
+        interacted=CandidateSet(articles=[]),
+        interest_profile=InterestProfile(entity_interests=[], click_history=[]),
+        num_recs=1,
+    )
+
+    payload = v5.model_dump(mode="json")
+    assert "candidates" in payload
+    assert {"articles", "default_package_id"}.isdisjoint(payload)

--- a/tests/api/test_v6.py
+++ b/tests/api/test_v6.py
@@ -81,7 +81,7 @@ def test_v6_request_round_trip_separates_catalog_from_default_package() -> None:
             [article(ARTICLE_1_ID), article(ARTICLE_1_ID)],
             [package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID])],
             DEFAULT_PACKAGE_ID,
-            f"articles contains duplicate article IDs: {ARTICLE_1_ID}",
+            "articles duplicate article ID count: 1",
         ),
         (
             [article(ARTICLE_1_ID)],
@@ -90,19 +90,19 @@ def test_v6_request_round_trip_separates_catalog_from_default_package() -> None:
                 package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID]),
             ],
             DEFAULT_PACKAGE_ID,
-            f"article_packages contains duplicate package IDs: {DEFAULT_PACKAGE_ID}",
+            "article_packages duplicate package ID count: 1",
         ),
         (
             [article(ARTICLE_1_ID)],
             [package(DEFAULT_PACKAGE_ID, [ARTICLE_1_ID, ARTICLE_1_ID])],
             DEFAULT_PACKAGE_ID,
-            f"article package {DEFAULT_PACKAGE_ID} contains duplicate article IDs: {ARTICLE_1_ID}",
+            f"article package {DEFAULT_PACKAGE_ID} duplicate article ID count: 1",
         ),
         (
             [article(ARTICLE_1_ID)],
             [package(DEFAULT_PACKAGE_ID, [UNKNOWN_ARTICLE_ID])],
             DEFAULT_PACKAGE_ID,
-            f"article package {DEFAULT_PACKAGE_ID} references unknown article IDs: {UNKNOWN_ARTICLE_ID}",
+            f"article package {DEFAULT_PACKAGE_ID} unknown article reference count: 1",
         ),
         (
             [article(ARTICLE_1_ID)],


### PR DESCRIPTION
This adds Recommendation API V6 as an additive contract. V6 separates the complete `articles` catalog from `article_packages`, with `default_package_id` identifying ordinary recommendation eligibility. Duplicate article and package IDs, duplicate references, missing default packages, and dangling references fail validation.

V1–V5 models, aliases, serialized behavior, and production defaults are unchanged. Platform serialization, recommender support, ProPublica behavior, and V6 activation will be separate PRs.

Validated with:

- `python -m pytest -v tests/` — 18 passed
- `pre-commit run --all-files`
- `ruff check src/poprox_concepts tests`
- `ruff format --check src/poprox_concepts tests`

Tool-assisted drafting, testing, and review; I reviewed and own the final change.
